### PR TITLE
Remove donate link on mobile

### DIFF
--- a/src/App.html
+++ b/src/App.html
@@ -82,14 +82,6 @@
       <span class="link" @click="openNav">
         <router-link to="/license">License</router-link>
       </span>
-      <span class="separator">
-        <img alt="" src="./assets/dot.png" />
-      </span>
-      <span class="link">
-        <a href="https://paypal.me/cocomaterial" title="Enjoying the site? Support our work!"
-          >⭐️ Donate</a
-        >
-      </span>
     </div>
   </div>
   <footer>


### PR DESCRIPTION
Turns out the Donate link was never removed from the mobile version 🤦🏼

This PR fixes that